### PR TITLE
Hotfix for missing renderPlayerList on updateUser Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/downloads/Talaren/FoundryVTT-PlayerListStatus/latest/module.zip?style=for-the-badge)
 ![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https://forge-vtt.com/api/bazaar/package/playerListStatus&colorB=green&style=for-the-badge)
 
-![Foundry Core Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/latest/download/module.json&label=Foundry%20Version&query=$.compatibleCoreVersion&colorB=green&style=for-the-badge)
-
 ![Foundry Core Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/latest/download/module.json&label=Foundry%20Version&query=$.compatibility.verified&colorB=green&style=for-the-badge)
 
 # FoundryVTT Library: PlayerList Status

--- a/module.json
+++ b/module.json
@@ -12,12 +12,12 @@
 			}
 		}
 	],
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"esmodules": [
 		"scripts/playerliststatus.js"
 	],
 	"manifest": "https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/latest/download/module.json",
-	"download": "https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/download/3.1.0/module.zip",
+	"download": "https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/download/3.1.1/module.zip",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "12.324",

--- a/scripts/playerliststatus.js
+++ b/scripts/playerliststatus.js
@@ -15,5 +15,10 @@ Hooks.once('ready', () => {
     Hooks.on('renderPlayerList', (foundry, html, data) => {
         game.playerListStatus.render(foundry, html, data);
     });
+
+    Hooks.on('updateUser', (user, props, mods, id) => {
+        game.users.apps.find((app)=>app instanceof PlayerList)?.render();
+    })
+
     Hooks.callAll("playerListStatusReady", game.playerListStatus);
 })


### PR DESCRIPTION
- Foundry 12 changes Hooks and UserList was not refreshed after updateUser