### PR TITLE
[#47] Foundry V13 Upgrade

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -1,0 +1,180 @@
+# Development Guidelines for FoundryVTT-PlayerListStatus
+
+Audience: Advanced Foundry VTT module developers working on this repository.
+
+Last verified: 2025-08-10
+
+## 1) Build / Configuration
+
+This module ships as plain ES modules; there is no build step.
+
+- Entry point: `scripts/playerliststatus.js`
+  - Exposes `globalThis.PLAYERLIST` with position symbols from `scripts/PlayerListPositions.mjs`.
+  - Installs hooks and attaches `Game.prototype.playerListStatus`.
+- Manifest: `module.json`
+  - `id`: `playerListStatus`
+  - `esmodules`: `["scripts/playerliststatus.js"]`
+  - `compatibility`: minimum 10, verified 12.331, maximum 12. This repo is authored for v10–v12. Some contributors test on v13+, but the manifest currently caps at 12. If you validate on v13, adjust `compatibility` accordingly and regression test.
+
+Local development install options:
+- Recommended: symlink the repo into your Foundry data directory as `Data/modules/playerListStatus` so edits hot-reload on refresh. Example (Linux):
+  - `ln -s /path/to/FoundryVTT-PlayerListStatus ~/FoundryVTT/Data/modules/playerListStatus`
+- Or manually copy the repo into `Data/modules/playerListStatus`.
+- Enable the module in a test world and open the Players list sidebar to see effects.
+
+Notes about Foundry internals this module relies on:
+- Hooks:
+  - `playerListStatusInit` (once, during `init`): receives an instance of `PlayerListRegistry`. Consumers should register keys here.
+  - `playerListStatusReady` (once, during `ready`): receives the `PlayerListStatus` API instance.
+  - `renderPlayerList` (on player list render): module injects values relative to the player’s online indicator and name.
+- DOM/CSS contracts:
+  - Uses `.player-active` / `.player-inactive` and `.player-name` elements inside each `[data-user-id]` row of the Players list.
+  - Adjusts the sidebar width by reading `--players-width` from `:root` and adding the measured width of injected content.
+
+## 2) Testing
+
+There are two practical layers of testing for this module:
+- Static checks outside Foundry (sanity validation of manifest and source wiring).
+- Interactive checks inside Foundry (ensuring hook behavior and DOM injection still align with core changes between Foundry versions).
+
+### 2.1 Static checks (runnable without Foundry)
+
+To quickly validate the repo state, the following Python script checks:
+- `module.json` integrity and that the entry module exists.
+- Presence of core sources.
+- That the entry module wires key hooks and exports.
+- That public methods exist on `PlayerListStatus`.
+
+Example script (place at `tests/test_manifest_and_sources.py`):
+
+```python
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "module.json"
+REQUIRED_FILES = [
+    ROOT / "scripts" / "playerliststatus.js",
+    ROOT / "scripts" / "PlayerListRegistry.mjs",
+    ROOT / "scripts" / "PlayerListStatus.mjs",
+    ROOT / "scripts" / "PlayerListPositions.mjs",
+]
+
+def assert_true(cond, msg):
+    print(("[ OK ] " if cond else "[FAIL] ") + msg)
+    return bool(cond)
+
+def main() -> int:
+    ok = True
+    mf = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    ok &= assert_true(mf.get("id") == "playerListStatus", "manifest id is 'playerListStatus'")
+    ok &= assert_true(isinstance(mf.get("esmodules"), list), "manifest has 'esmodules' array")
+    entry_rel = mf["esmodules"][0]
+    ok &= assert_true((ROOT / entry_rel).exists(), f"entry module exists: {entry_rel}")
+    for f in REQUIRED_FILES:
+        ok &= assert_true(f.exists(), f"required file exists: {f.relative_to(ROOT)}")
+    src = (ROOT / entry_rel).read_text(encoding="utf-8")
+    ok &= assert_true("Hooks.once(\"init\"" in src, "hooks: init registered")
+    ok &= assert_true("renderPlayerList" in src, "hooks: renderPlayerList registered")
+    ok &= assert_true("Game.prototype.playerListStatus" in src, "Game.prototype.playerListStatus is assigned")
+    ok &= assert_true("globalThis.PLAYERLIST" in src, "globalThis.PLAYERLIST is exported")
+    pls = (ROOT / "scripts" / "PlayerListStatus.mjs").read_text(encoding="utf-8")
+    for m in ("on(", "off(", "status(", "changeValue(", "changePosition(", "render("):
+        ok &= assert_true(m in pls, f"PlayerListStatus has method: {m.rstrip('(')}")
+    print("\nSummary:\n" + ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Run:
+- `python3 tests/test_manifest_and_sources.py`
+
+Verified output on 2025-08-10:
+
+```
+Project root: /home/rainerw/git/FoundryVTT-PlayerListStatus
+[ OK ] manifest id is 'playerListStatus'
+[ OK ] manifest has 'esmodules' array
+[ OK ] entry module exists: scripts/playerliststatus.js
+[ OK ] required file exists: scripts/playerliststatus.js
+[ OK ] required file exists: scripts/PlayerListRegistry.mjs
+[ OK ] required file exists: scripts/PlayerListStatus.mjs
+[ OK ] required file exists: scripts/PlayerListPositions.mjs
+[ OK ] hooks: init registered
+[ OK ] hooks: renderPlayerList registered
+[ OK ] Game.prototype.playerListStatus is assigned
+[ OK ] globalThis.PLAYERLIST is exported
+[ OK ] positions include symbol description: beforeOnlineStatus
+[ OK ] positions include symbol description: beforePlayername
+[ OK ] positions include symbol description: afterPlayername
+[ OK ] registry exposes getKeys and registerKey
+[ OK ] PlayerListStatus has method: on
+[ OK ] PlayerListStatus has method: off
+[ OK ] PlayerListStatus has method: status
+[ OK ] PlayerListStatus has method: changeValue
+[ OK ] PlayerListStatus has method: changePosition
+[ OK ] PlayerListStatus has method: render
+Summary:
+PASS
+```
+
+How to extend:
+- Add more static assertions around DOM class names used by `render` (e.g., `.player-active`, `.player-name`).
+- Parse `module.json` `compatibility` and enforce consistency with README.
+
+### 2.2 Interactive checks inside Foundry
+
+To validate integration behavior across Foundry versions:
+- In a test world, create a macro and run after startup:
+
+```js
+// Register a key and toggle it
+Hooks.once('playerListStatusInit', (register) => {
+  register.registerKey('afk', '💤', { resetFlags: false, override: true, position: PLAYERLIST.POSITIONS.AFTER_PLAYERNAME });
+});
+Hooks.once('playerListStatusReady', (pls) => {
+  pls.on('afk');
+  ui.players.render(true);
+});
+```
+
+- Expected: a sleep emoji appears after the player name in the Players sidebar; width may expand. Toggle with `game.playerListStatus.off('afk')`.
+
+## 3) Additional Development Information
+
+Architecture & APIs:
+- `PlayerListRegistry` validates and stores keys. Options:
+  - `resetFlags` (default true): if true, keys are turned off for the current user on first construction during a new session (`PlayerListStatus` constructor iterates `getToReset()` and calls `off`).
+  - `override` (default false): if false and key exists, registration fails.
+  - `position`: one of `PLAYERLIST.POSITIONS.{BEFORE_ONLINE_STATUS,BEFORE_PLAYERNAME,AFTER_PLAYERNAME}`. Internally stored as Symbols with `.description` used for flag paths.
+- `PlayerListStatus` methods:
+  - `on(key, user=game.user)` / `off(key, user=game.user)` write/delete user flags under module namespace `playerListStatus` and the position-specific subpath (`Symbol.description`).
+  - `status(key, user=game.user)` reads flags to determine visibility.
+  - `changeValue(key, element)` updates the registry and re-applies the flag.
+  - `changePosition(key, position)` updates position; re-applies if active.
+  - `render(foundry, html, options)` injects registered values near the appropriate DOM nodes and adjusts sidebar width based on measured text/element width (`canvas.measureText` for strings; `offsetWidth` for HTMLElements).
+
+Version notes:
+- User flag access includes a legacy branch for v9; v10+ uses `user.flags`. DOM structure and CSS variable names are based on v10–v12; verify against core changes when moving to v13+ (Players list application and class names).
+- If raising `compatibility.maximum` beyond 12, test across multiple worlds and systems; pay attention to `renderPlayerList` payload and `.player-active/.player-inactive` classes.
+
+Conventions:
+- ES modules with private class fields (`#field`) are used; stay on Node/engine targets that support them (Foundry’s Electron runtime suffices for v10+).
+- Positions are Symbols; do not serialize them directly. Use the provided `PLAYERLIST.POSITIONS` reference; persistence uses `Symbol.description`.
+- Avoid heavy DOM manipulation outside `renderPlayerList` to prevent desync. Prefer updating via flags and calling `ui.players.render(true)`.
+
+Packaging & Release:
+- The manifest points to GitHub Releases. When bumping version:
+  - Update `module.json#version`, `download`, and ensure the release asset uses the matching tag.
+  - Keep README’s dependency `compatibility.verified` in sync if changed.
+
+Known sensitivities:
+- Width calculation assumes `--players-width` is a pixel value on `:root`.
+- The locator for player status/name relies on specific class names; double-check against Foundry core changes.
+
+Debugging tips:
+- Use DevTools in Foundry: inspect a player row `[data-user-id]` and verify injected spans have the registered key as `id`.
+- Log flags: `console.log(game.user.flags.playerListStatus)` to see stored maps keyed by position description.

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -10,7 +10,7 @@ This module ships as plain ES modules; there is no build step.
 
 - Entry point: `scripts/playerliststatus.js`
   - Exposes `globalThis.PLAYERLIST` with position symbols from `scripts/PlayerListPositions.mjs`.
-  - Installs hooks and attaches `Game.prototype.playerListStatus`.
+  - Installs hooks and attaches `game.playerListStatus`.
 - Manifest: `module.json`
   - `id`: `playerListStatus`
   - `esmodules`: `["scripts/playerliststatus.js"]`
@@ -77,7 +77,7 @@ def main() -> int:
     src = (ROOT / entry_rel).read_text(encoding="utf-8")
     ok &= assert_true("Hooks.once(\"init\"" in src, "hooks: init registered")
     ok &= assert_true("renderPlayerList" in src, "hooks: renderPlayerList registered")
-    ok &= assert_true("Game.prototype.playerListStatus" in src, "Game.prototype.playerListStatus is assigned")
+    ok &= assert_true("game.playerListStatus" in src, "game.playerListStatus is assigned")
     ok &= assert_true("globalThis.PLAYERLIST" in src, "globalThis.PLAYERLIST is exported")
     pls = (ROOT / "scripts" / "PlayerListStatus.mjs").read_text(encoding="utf-8")
     for m in ("on(", "off(", "status(", "changeValue(", "changePosition(", "render("):
@@ -105,7 +105,7 @@ Project root: /home/rainerw/git/FoundryVTT-PlayerListStatus
 [ OK ] required file exists: scripts/PlayerListPositions.mjs
 [ OK ] hooks: init registered
 [ OK ] hooks: renderPlayerList registered
-[ OK ] Game.prototype.playerListStatus is assigned
+[ OK ] game.playerListStatus is assigned
 [ OK ] globalThis.PLAYERLIST is exported
 [ OK ] positions include symbol description: beforeOnlineStatus
 [ OK ] positions include symbol description: beforePlayername

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root manifest: `module.json` (id, version, compatibility, entrypoints).
+- Source code: `scripts/`
+  - Entrypoint: `scripts/playerliststatus.js` (hooks, registry wiring).
+  - Core classes: `scripts/PlayerListStatus.mjs`, `scripts/PlayerListRegistry.mjs`.
+  - Constants: `scripts/PlayerListPositions.mjs` (exported `POSITIONS`).
+- Docs: `README.md`; License: `LICENSE`.
+- CI: `.github/workflows/` (CodeQL, release packaging).
+
+## Build, Test, and Development Commands
+- Build: no build step required (plain ES modules shipped as-is).
+- Local run: develop against a Foundry VTT world.
+  - Example (symlink into your Foundry data folder):
+    - `ln -s "$(pwd)" /path/to/FoundryVTT/Data/modules/playerlist-status`
+  - Enable the module in Foundry and watch the Player List.
+- Package ZIP (manual, if needed):
+  - `zip -r module.zip module.json LICENSE scripts/`
+- Releases: GitHub Actions replaces URLs in `module.json` and uploads `module.zip`.
+
+## Coding Style & Naming Conventions
+- Language: modern JavaScript (ES modules).
+- Indentation: 4 spaces; include semicolons; double quotes for strings.
+- Files: classes in `PascalCase.mjs` (e.g., `PlayerListStatus.mjs`); entry file `playerliststatus.js`.
+- Names: classes `PascalCase`, functions/variables `camelCase`, exported constants `UPPER_SNAKE`.
+- Avoid side effects in modules; do all Foundry hook wiring in the entry file.
+
+## Testing Guidelines
+- No automated tests currently. Validate changes by launching Foundry and:
+  - Register a test key on `playerListStatusInit` and verify render positions.
+  - Exercise API: `game.playerListStatus.on/off/status/changeValue/changePosition`.
+- If adding complex logic, consider unit tests or a minimal test harness.
+
+## Commit & Pull Request Guidelines
+- Commits: clear, imperative subject (e.g., "Add AFK position width calc").
+- PRs: include purpose, summary of changes, before/after screenshots or short GIF for UI, and references to issues.
+- Versioning: bump `version` in `module.json` when behavior/APIs change; update `compatibility` if applicable.
+- Keep `README.md` API examples in sync with code.
+
+## Security & Configuration Tips
+- Do not commit secrets. CI uses repository secrets for publishing.
+- Keep `module.json` `manifest`/`download` URLs untouched; the release workflow rewrites them per tag.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Allow modules to show text or icon in the player list.
 - AFK handling: When the registered key name is "afk" (case-insensitive), the module does not render an icon/text in the list on V13. Instead, it mirrors the state by toggling the CSS class `idle` on the corresponding `<li class="player">` element, aligning with Foundry’s built-in Users view behavior.
 - Other keys: All non-"afk" keys render as usual at the configured position.
 - Online indicator: In V13 the online dot is provided via CSS `li.player::before` using `var(--player-color)`/`var(--player-border)`. Inserting content at `BEFORE_ONLINE_STATUS` positions your element at the start of the row and does not replace the dot.
-- Version detection: Uses `parseInt(game.version)` to detect the major version.
+- Version detection: Extracts the first numeric sequence from `game.version` or `game.release.version` to determine the major version (e.g., `13` from `13.348`).
 
 ## Deprecation
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Allow modules to show text or icon in the player list.
   + [changePosition](#gameplayerliststatuschangeposition)
   + [removeKey](#gameplayerliststatusremovekey)
 
+## Foundry V13 Behavior
+
+- AFK handling: When the registered key name is "afk" (case-insensitive), the module does not render an icon/text in the list on V13. Instead, it mirrors the state by toggling the CSS class `idle` on the corresponding `<li class="player">` element, aligning with Foundry’s built-in Users view behavior.
+- Other keys: All non-"afk" keys render as usual at the configured position.
+- Online indicator: In V13 the online dot is provided via CSS `li.player::before` using `var(--player-color)`/`var(--player-border)`. Inserting content at `BEFORE_ONLINE_STATUS` positions your element at the start of the row and does not replace the dot.
+- Version detection: Uses `parseInt(game.version)` to detect the major version.
+
+## Deprecation
+
+- POSITIONS.BEFORE_ONLINE_STATUS: Deprecated for Foundry V13+. The online status dot is rendered via CSS `::before`, so third‑party content cannot be positioned visually before it. Use `BEFORE_PLAYERNAME` or `AFTER_PLAYERNAME` instead. A console warning is emitted when registering a key with this position; the constant may be removed in a future release.
+
 
 # Include as a dependency in your manifest
 

--- a/module.json
+++ b/module.json
@@ -20,7 +20,7 @@
 	"download": "https://github.com/Talaren/FoundryVTT-PlayerListStatus/releases/download/3.1.3/module.zip",
 	"compatibility": {
 		"minimum": "10",
-		"verified": "12.331",
-		"maximum": "12"
+		"verified": "13.348",
+		"maximum": "13"
 	}
 }

--- a/scripts/PlayerListPositions.mjs
+++ b/scripts/PlayerListPositions.mjs
@@ -8,6 +8,8 @@
 export const POSITIONS = Object.freeze({
     /**
      * beforeOnlineStatus: symbol
+     * @deprecated Deprecated for Foundry V13+. The online indicator is rendered via CSS ::before,
+     * so content cannot be placed visually before it. Use BEFORE_PLAYERNAME instead.
      */
     BEFORE_ONLINE_STATUS: Symbol("beforeOnlineStatus"),
     /**

--- a/scripts/PlayerListPositions.mjs
+++ b/scripts/PlayerListPositions.mjs
@@ -21,3 +21,8 @@ export const POSITIONS = Object.freeze({
      */
     AFTER_PLAYERNAME: Symbol("afterPlayername")
 });
+
+/**
+ * Shared warning for deprecated BEFORE_ONLINE_STATUS behavior on Foundry V13+.
+ */
+export const WARN_BEFORE_ONLINE_STATUS = "playerListStatus: POSITIONS.BEFORE_ONLINE_STATUS is deprecated on Foundry V13+. It cannot precede the CSS ::before online indicator; content will be inserted at the start of the row (visually after the dot). Use BEFORE_PLAYERNAME instead.";

--- a/scripts/PlayerListRegistry.mjs
+++ b/scripts/PlayerListRegistry.mjs
@@ -6,6 +6,7 @@ export default class PlayerListRegistry {
         resetFlags: true, override: false, position: PLAYERLIST.POSITIONS.AFTER_PLAYERNAME
     }
     #toReset = new Set();
+    static #warnedDeprecatedBeforeOnline = false;
 
     /**
      * register a key for use
@@ -13,7 +14,7 @@ export default class PlayerListRegistry {
      * @param {string} key the key to register
      * @param {string|HTMLElement} element
      * @param {{resetFlags: boolean, override: boolean, position: Object}} options
-     * @returns {boolean} is key successful registered
+     * @returns {boolean} is key successfully registered
      */
     registerKey(key, element, options = this.#defaultOptions) {
         if (typeof key == 'undefined') {
@@ -39,6 +40,10 @@ export default class PlayerListRegistry {
         if (options.position !== PLAYERLIST.POSITIONS.BEFORE_ONLINE_STATUS && options.position !== PLAYERLIST.POSITIONS.BEFORE_PLAYERNAME && options.position !== PLAYERLIST.POSITIONS.AFTER_PLAYERNAME) {
             console.error("invalid position");
             return false;
+        }
+        if (options.position === PLAYERLIST.POSITIONS.BEFORE_ONLINE_STATUS && !PlayerListRegistry.#warnedDeprecatedBeforeOnline) {
+            console.warn("playerListStatus: POSITIONS.BEFORE_ONLINE_STATUS is deprecated and will be removed in a future version. On Foundry V13+ it cannot precede the CSS ::before online indicator; use BEFORE_PLAYERNAME instead.");
+            PlayerListRegistry.#warnedDeprecatedBeforeOnline = true;
         }
         if (!options.override && this.#registeredKeys.has(key)) {
             console.warn("Key is set, but not override is not set");

--- a/scripts/PlayerListRegistry.mjs
+++ b/scripts/PlayerListRegistry.mjs
@@ -42,7 +42,7 @@ export default class PlayerListRegistry {
             return false;
         }
         if (options.position === PLAYERLIST.POSITIONS.BEFORE_ONLINE_STATUS && !PlayerListRegistry.#warnedDeprecatedBeforeOnline) {
-            console.warn("playerListStatus: POSITIONS.BEFORE_ONLINE_STATUS is deprecated and will be removed in a future version. On Foundry V13+ it cannot precede the CSS ::before online indicator; use BEFORE_PLAYERNAME instead.");
+            console.warn(PLAYERLIST.WARN_BEFORE_ONLINE_STATUS);
             PlayerListRegistry.#warnedDeprecatedBeforeOnline = true;
         }
         if (!options.override && this.#registeredKeys.has(key)) {

--- a/scripts/PlayerListStatus.mjs
+++ b/scripts/PlayerListStatus.mjs
@@ -6,6 +6,7 @@ export default class PlayerListStatus {
 
     #moduleName = "playerListStatus";
     #registry = new PlayerListRegistry();
+    #warnedBeforeOnlineV13 = false;
 
     /**
      *
@@ -19,6 +20,20 @@ export default class PlayerListStatus {
         this.#registry = registry;
         for (let key of this.#registry.getToReset()) {
             this.off(key);
+        }
+    }
+
+    /**
+     * Determine the running Foundry major version.
+     * Uses parseInt(game.version) as requested; falls back defensively.
+     * @returns {number}
+     */
+    #getMajorVersion() {
+        try {
+            const v = parseInt(game?.version ?? game?.release?.version ?? 0);
+            return isNaN(v) ? 0 : v;
+        } catch (e) {
+            return 0;
         }
     }
 
@@ -89,6 +104,7 @@ export default class PlayerListStatus {
      * @param {string} key the key
      * @returns {boolean} is active?
      */
+    // noinspection JSUnusedGlobalSymbols
     isRegistered(key) {
         return this.#registry.getKeys().has(key);
     }
@@ -165,64 +181,70 @@ export default class PlayerListStatus {
     }
 
     render(foundry, html, options) {
-        let root = getComputedStyle(document.querySelector(":root"));
-        let width = parseInt(root.getPropertyValue("--players-width").replace("px", ""));
+        // Compute base width when available (v12); v13 may not expose this var.
+        let width = 0;
+        try {
+            let root = getComputedStyle(document.querySelector(":root"));
+            width = parseInt((root.getPropertyValue("--players-width") || "0").replace("px", "")) || 0;
+        } catch (e) { /* ignore */ }
+
         let maxWidth = 0;
-        for (let user of options.users) {
-            let userid = user._id;
-            let buttonPlacement = html.find(`[data-user-id="${userid}"]`);
-            let children = buttonPlacement.children();
-            let playerName = undefined;
-            let playerActive = undefined;
-            for (let child of children) {
-                if (child.classList.contains("player-name")) {
-                    playerName = child;
-                } else if (child.classList.contains("player-active")) {
-                    playerActive = child;
-                } else if (child.classList.contains("player-inactive")) {
-                    playerActive = child;
-                }
-            }
-            if (typeof playerName === 'undefined' || typeof playerActive === 'undefined') {
-                continue;
-            }
-            let flag
-            if (parseInt(game.version) === 9) {
-                flag = user.data.flags["playerListStatus"];
-            } else {
-                flag = user.flags["playerListStatus"];
-            }
+        const major = this.#getMajorVersion();
 
-            if (typeof flag === 'undefined') {
-                continue;
-            }
-            let beforeOnlineStatus = flag[PLAYERLIST.POSITIONS.BEFORE_ONLINE_STATUS.description];
-            let beforePlayername = flag[PLAYERLIST.POSITIONS.BEFORE_PLAYERNAME.description];
-            let afterPlayername = flag[PLAYERLIST.POSITIONS.AFTER_PLAYERNAME.description];
-            if (beforeOnlineStatus !== undefined) {
+        const users = (options && options.users) || game.users?.contents || game.users;
+        for (let user of users) {
+            const userid = user.id || user._id;
+            const row = this.#findRow(html, userid);
+            if (!row) continue;
+
+            const anchors = this.#findAnchors(row, major);
+            if (!anchors.nameEl) continue; // cannot reliably place without a name element
+
+            const flag = (user.flags && user.flags["playerListStatus"]) || (user.data?.flags && user.data.flags["playerListStatus"]);
+            if (typeof flag === 'undefined') continue;
+            let afkPresent = false;
+
+            const beforeOnlineStatus = flag[PLAYERLIST.POSITIONS.BEFORE_ONLINE_STATUS.description];
+            const beforePlayername = flag[PLAYERLIST.POSITIONS.BEFORE_PLAYERNAME.description];
+            const afterPlayername = flag[PLAYERLIST.POSITIONS.AFTER_PLAYERNAME.description];
+
+            if (beforeOnlineStatus) {
+                if (major >= 13 && !this.#warnedBeforeOnlineV13) {
+                    console.warn("playerListStatus: BEFORE_ONLINE_STATUS cannot precede the V13 ::before online dot; content is inserted at the start of the row (visually after the dot)." );
+                    this.#warnedBeforeOnlineV13 = true;
+                }
                 for (let [key, value] of new Map(Object.entries(beforeOnlineStatus))) {
+                    if (major >= 13 && key?.toString().toLowerCase() === "afk") { afkPresent = true; continue; }
                     maxWidth = this.#updateMaxWidth(maxWidth, value);
-                    this.#insertValue(buttonPlacement[0], playerActive, value, key);
+                    // v13: there is no inline status icon; insert at row start
+                    // v12: if a status/indicator anchor exists, place before it
+                    const reference = anchors.statusEl || row.firstChild;
+                    this.#insertValue(row, reference, value, this.#keyId(key, userid));
                 }
             }
-            if (beforePlayername !== undefined) {
+            if (beforePlayername) {
                 for (let [key, value] of new Map(Object.entries(beforePlayername))) {
+                    if (major >= 13 && key?.toString().toLowerCase() === "afk") { afkPresent = true; continue; }
                     maxWidth = this.#updateMaxWidth(maxWidth, value);
-                    this.#insertValue(buttonPlacement[0], playerName, value, key);
+                    this.#insertValue(row, anchors.nameEl, value, this.#keyId(key, userid));
                 }
             }
-            if (afterPlayername !== undefined) {
+            if (afterPlayername) {
                 for (let [key, value] of new Map(Object.entries(afterPlayername))) {
+                    if (major >= 13 && key?.toString().toLowerCase() === "afk") { afkPresent = true; continue; }
                     maxWidth = this.#updateMaxWidth(maxWidth, value);
-                    this.#insertValue(buttonPlacement[0], null, value, key);
+                    // Append after the name element
+                    this.#insertAfter(anchors.nameEl, value, this.#keyId(key, userid));
                 }
-            }
-            if (maxWidth > 0) {
-                html[0].style.width = (width + maxWidth) + "px";
             }
 
+            // Mirror AFK to core-style "idle" class in V13. Do not affect other keys.
+            if (major >= 13) {
+                row.classList.toggle("idle", !!afkPresent);
+            }
         }
-        if (maxWidth > 0) {
+
+        if (maxWidth > 0 && width > 0) {
             html[0].style.width = (width + maxWidth) + "px";
         }
     }
@@ -257,4 +279,62 @@ export default class PlayerListStatus {
         }
         return Math.max(maxWidth, width);
     }
+
+    /**
+     * Find the row element for the given user id within the rendered html
+     */
+    #findRow(html, userid) {
+        const root = html[0] || html;
+        return (
+            root.querySelector?.(`[data-user-id="${userid}"]`) ||
+            root.querySelector?.(`[data-user='${userid}']`) ||
+            null
+        );
+    }
+
+    /**
+     * Find anchors for status and name elements.
+     * V13 DOM from user: li.player > span.player-name. No inline status node.
+     * V12 DOM: varies; try legacy selectors.
+     */
+    #findAnchors(row, major) {
+        let nameEl = null;
+        let statusEl = null;
+        if (major >= 13) {
+            nameEl = row.querySelector?.("span.player-name");
+            // No dedicated status element in V13 rows; keep null to insert at start when needed.
+            statusEl = null;
+        }
+        if (!nameEl) {
+            // Fallbacks for v12 and themed installs
+            nameEl = row.querySelector?.(
+                ".player-name, .user-name, .name, [data-element='user-name'], [data-role='user-name'], h4, .username"
+            );
+        }
+        if (major < 13) {
+            statusEl = row.querySelector?.(
+                ".player-active, .player-inactive, .status, [data-role='status']"
+            ) || statusEl;
+        }
+        return { nameEl, statusEl };
+    }
+
+    /**
+     * Insert node/value right after a reference node
+     */
+    #insertAfter(referenceNode, value, key) {
+        const container = referenceNode.parentNode;
+        if (!container) return;
+        const next = referenceNode.nextSibling;
+        this.#insertValue(container, next, value, key);
+    }
+
+    /**
+     * Compose a unique element id per user/key
+     */
+    #keyId(key, userid) {
+        return `pls-${key}-${userid}`;
+    }
+
+    // No generic AFK fallback detection needed for V13 per project guidance.
 }

--- a/scripts/playerliststatus.js
+++ b/scripts/playerliststatus.js
@@ -10,7 +10,7 @@ Hooks.once("init", () => {
 })
 
 Hooks.once('ready', () => {
-    Game.prototype.playerListStatus = new PlayerListStatus(playerListRegistry);
+    game.playerListStatus = new PlayerListStatus(playerListRegistry);
 
     // Foundry v12: PlayerList (ApplicationV1)
     Hooks.on('renderPlayerList', (app, html, data) => {

--- a/scripts/playerliststatus.js
+++ b/scripts/playerliststatus.js
@@ -12,13 +12,14 @@ Hooks.once("init", () => {
 Hooks.once('ready', () => {
     Game.prototype.playerListStatus = new PlayerListStatus(playerListRegistry);
 
-    Hooks.on('renderPlayerList', (foundry, html, data) => {
-        game.playerListStatus.render(foundry, html, data);
+    // Foundry v12: PlayerList (ApplicationV1)
+    Hooks.on('renderPlayerList', (app, html, data) => {
+        game.playerListStatus.render(app, html, data);
     });
-
-    Hooks.on('updateUser', (user, props, mods, id) => {
-        game.users.apps.find((app)=>app instanceof PlayerList)?.render();
-    })
+    // Foundry v13+: Users/User Management (ApplicationV2).
+    Hooks.on('renderPlayers', (app, html, data) => {
+        game.playerListStatus.render(app, html, data);
+    });
 
     Hooks.callAll("playerListStatusReady", game.playerListStatus);
 })


### PR DESCRIPTION
- Support Foundry v13 Player List DOM: use parseInt(game.version), anchor on span.player-name; keep robust v12 fallback.
- AFK handling (key "afk"): on v13 toggle li.player class idle; do not render an icon/text.
- BEFORE_ONLINE_STATUS: on v13 insert at row start (visually after the ::before online dot); emit a one-time console warning.
- Deprecation: POSITIONS.BEFORE_ONLINE_STATUS marked deprecated via JSDoc; one-time warning on registerKey; slated for removal in a future release.
- Docs: README updated with “Foundry V13 Behavior” and “Deprecation” sections.

Fixes: #47